### PR TITLE
Update catalog to required in plugin yaml

### DIFF
--- a/drivers/starburst/resources/metabase-plugin.yaml
+++ b/drivers/starburst/resources/metabase-plugin.yaml
@@ -20,7 +20,7 @@ driver:
         - name: catalog
           placeholder: tpch
           display-name: Catalog
-          required: false
+          required: true
     - name: schema
       display-name: Schema (optional)
       required: false


### PR DESCRIPTION
adding `required: true` forces the user to enter a value, tpch will no longer be a default, but will still act as a placeholder. 