### PR TITLE
AN-628: add helper text when adding new database

### DIFF
--- a/drivers/starburst/resources/metabase-plugin.yaml
+++ b/drivers/starburst/resources/metabase-plugin.yaml
@@ -21,9 +21,11 @@ driver:
           placeholder: tpch
           display-name: Catalog
           required: true
+          helper-text: Starburst Catalogs contain schemas and reference data sources via a connector.
     - name: schema
       display-name: Schema (optional)
       required: false
+      helper-text: Only add tables to Metabase that come from a specific schema.
     - merge:
         - user
         - required: false


### PR DESCRIPTION
Adds helper text for the catalogs and schemas when adding a new database of type Starburst