### PR TITLE
UI Fix for advanced-options-start

### DIFF
--- a/drivers/starburst/resources/metabase-plugin.yaml
+++ b/drivers/starburst/resources/metabase-plugin.yaml
@@ -33,10 +33,10 @@ driver:
         - password
         - required: false
     - ssl
+    - advanced-options-start
     - merge:
         - additional-options
         - placeholder: "trustServerCertificate=false"
-    - advanced-options-start
     - default-advanced-options
 
 init:


### PR DESCRIPTION
Make sure ``Additional JDBC connection string options`` is under `advanced options` drop down drop down.

### BAD
<img width="795" alt="Screen Shot 2022-07-14 at 4 19 04 PM" src="https://user-images.githubusercontent.com/8988880/179075954-33e8238b-8ced-469c-8433-38c9cbd139d6.png">

### Goood!
<img width="622" alt="Screen Shot 2022-07-14 at 4 17 37 PM" src="https://user-images.githubusercontent.com/8988880/179075975-6ba05d42-9104-450d-852b-ac25b40a8a00.png">

 