### PR TITLE
disable foreign key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Bump Metabase version to v1.44.0
+- Disable Foreign Key feature
+
 ## [1.0.5] - 2022-07-11
 
 -   Add default-advanced-options

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ This command starts a local Metabase server on port `3000`. If you want to build
 ### Testing Driver
 Once you have built all required resources with the `make build` command, run `make test`. This command builds your local driver changes and then starts Starburst driver tests.
 
+#### Executing Sepecific Tests
+You can cd into the metabase repo and run commands like:
+`DRIVERS=starburst clojure -X:dev:drivers:drivers-dev:test :only metabase.query-processor-test.timezones-test/filter-test`
+
+or even
+
+`DRIVERS=starburst clojure -X:dev:drivers:drivers-dev:test :only metabase.query-processor-test.timezones-test`
+
 ### Releasing Driver
 To create a release from the `main` branch follow the below steps.
 

--- a/app_versions.json
+++ b/app_versions.json
@@ -1,5 +1,5 @@
 {
     "trino": "384",
     "clojure": "1.11.0.1100",
-    "metabase": "v1.43.4"
+    "metabase": "v1.44.0"
 }

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -28,5 +28,5 @@
                               :native-parameters               true
                               :expression-aggregations         true
                               :binning                         true
-                              :foreign-keys                    true}]
+                              :foreign-keys                    false}]
   (defmethod driver/supports? [:starburst feature] [_ _] supported?))

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -21,6 +21,11 @@
   [_]
   :monday)
 
+(defmethod driver/describe-table-fks :starburst [_ _ _]
+  ;; Trino does not support finding foreign key metadata tables, but some connectors support foreign keys.
+  ;; We have this return nil to avoid running unnecessary queries during fks sync.
+  nil)
+
 (doseq [[feature supported?] {:set-timezone                    true
                               :basic-aggregations              true
                               :standard-deviation-aggregations true
@@ -28,5 +33,5 @@
                               :native-parameters               true
                               :expression-aggregations         true
                               :binning                         true
-                              :foreign-keys                    false}]
+                              :foreign-keys                    true}]
   (defmethod driver/supports? [:starburst feature] [_ _] supported?))

--- a/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -17,6 +17,7 @@
             [metabase.config :as config]
             [metabase.connection-pool :as connection-pool]
             [metabase.driver :as driver]
+            [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.test.data.interface :as tx]
             [metabase.test.data.sql :as sql.tx]
@@ -139,8 +140,7 @@
   (let [sql ((get-method sql.tx/create-table-sql :sql/test-extensions) driver dbdef tabledef)]
     (str/replace sql #", PRIMARY KEY \([^)]+\)" "")))
 
-(defmethod tx/format-name :starburst
-  [_ table-or-field-name]
+(defmethod ddl.i/format-name :starburst [_ table-or-field-name]
   (u/snake-key table-or-field-name))
 
 ;; Trino doesn't support FKs, at least not adding them via DDL


### PR DESCRIPTION
Trino doesn't support inspecting foreign keys, so this PR overrides the `driver/describe-table-fks` function to just return nil. With this change, we avoid running extra needless queries during the metabase sync process. 

Also, the current version of Metabase has some breaking dependencies so I had to bump metabase version to 1.44.0 and fix failing tests. 

(Note: I will nee to squash these commits once approved)