### PR TITLE
Support for new datetime functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+- Bump Metabase version to v1.45.0
+- Adds [convertTimezone](https://www.metabase.com/docs/latest/questions/query-builder/expressions/converttimezone) support
+- Adds [datetimeDiff](https://www.metabase.com/docs/latest/questions/query-builder/expressions/datetimediff) support
+
 ## [1.0.7] - 2022-12-12
 
 -   Update trino test port to 8082

--- a/app_versions.json
+++ b/app_versions.json
@@ -1,5 +1,5 @@
 {
     "trino": "384",
     "clojure": "1.11.0.1100",
-    "metabase": "v1.44.0"
+    "metabase": "v1.45.0"
 }

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -33,5 +33,6 @@
                               :native-parameters               true
                               :expression-aggregations         true
                               :binning                         true
-                              :foreign-keys                    true}]
+                              :foreign-keys                    true
+                              :datetime-diff                   true}]
   (defmethod driver/supports? [:starburst feature] [_ _] supported?))

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -34,5 +34,6 @@
                               :expression-aggregations         true
                               :binning                         true
                               :foreign-keys                    true
-                              :datetime-diff                   true}]
+                              :datetime-diff                   true
+                              :convert-timezone                true}]
   (defmethod driver/supports? [:starburst feature] [_ _] supported?))

--- a/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
@@ -17,6 +17,7 @@
             [honeysql.helpers :as hh]
             [java-time :as t]
             [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.timezone :as qp.timezone]
@@ -248,3 +249,16 @@
         (hsql/call :date_diff (hx/literal unit) x-date y-date))
       (:hour :minute :second)
       (hsql/call :date_diff (hx/literal unit) x y))))
+
+(defmethod sql.qp/->honeysql [:starburst :convert-timezone]
+  [driver [_ arg target-timezone source-timezone]]
+  (let [expr         (sql.qp/->honeysql driver (cond-> arg
+                                                 (string? arg) u.date/parse))
+        with_timezone? (hx/is-of-type? expr #"(?i)^timestamp(?:\(\d+\))? with time zone$")
+        _ (sql.u/validate-convert-timezone-args with_timezone? target-timezone source-timezone)
+        expr (hsql/call :at_timezone
+                        (if with_timezone?
+                          expr
+                          (hsql/call :with_timezone expr (or source-timezone (qp.timezone/results-timezone-id))))
+                        target-timezone)]
+    (hx/with-database-type-info (hx/->timestamp expr) "timestamp")))

--- a/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
@@ -112,6 +112,10 @@
   [_ _ expr]
   expr)
 
+(defmethod sql.qp/date [:starburst :second-of-minute]
+  [_ _ expr]
+  (hsql/call :second (in-report-zone expr)))
+
 (defmethod sql.qp/date [:starburst :minute]
   [_ _ expr]
   (hsql/call :date_trunc (hx/literal :minute) (in-report-zone expr)))
@@ -148,6 +152,10 @@
   [_ _ expr]
   (sql.qp/adjust-start-of-week :starburst (partial hsql/call :date_trunc (hx/literal :week)) (in-report-zone expr)))
 
+(defmethod sql.qp/date [:starburst :week-of-year-iso]
+  [_ _ expr]
+  (hsql/call :week (in-report-zone expr)))
+
 (defmethod sql.qp/date [:starburst :month]
   [_ _ expr]
   (hsql/call :date_trunc (hx/literal :month) (in-report-zone expr)))
@@ -167,6 +175,10 @@
 (defmethod sql.qp/date [:starburst :year]
   [_ _ expr]
   (hsql/call :date_trunc (hx/literal :year) (in-report-zone expr)))
+
+(defmethod sql.qp/date [:starburst :year-of-era]
+  [_ _ expr]
+  (hsql/call :year (in-report-zone expr)))
 
 (defmethod sql.qp/current-datetime-honeysql-form :starburst
   [_]

--- a/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
@@ -98,7 +98,7 @@
         db-type     (hx/type-info->db-type type-info)]
     (if (and ;; AT TIME ZONE is only valid on these Trino types; if applied to something else (ex: `date`), then
              ;; an error will be thrown by the query analyzer
-         (contains? #{"timestamp" "timestamp with time zone" "time" "time with time zone"} db-type)
+         (and db-type (re-find #"(?i)^time(?:stamp)?(?:\(\d+\))?(?: with time zone)?$" db-type))
              ;; if one has already been set, don't do so again
          (not (::in-report-zone? (meta expr)))
          report-zone)

--- a/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -138,7 +138,7 @@
   [driver dbdef tabledef]
   ;; strip out the PRIMARY KEY stuff from the CREATE TABLE statement
   (let [sql ((get-method sql.tx/create-table-sql :sql/test-extensions) driver dbdef tabledef)]
-    (str/replace sql #", PRIMARY KEY \([^)]+\)" "")))
+    (str/replace sql #", PRIMARY KEY \([^)]+\)|NOT NULL" "")))
 
 (defmethod ddl.i/format-name :starburst [_ table-or-field-name]
   (u/snake-key table-or-field-name))

--- a/resources/docker/trino/entrypoint.sh
+++ b/resources/docker/trino/entrypoint.sh
@@ -46,7 +46,8 @@ geographical_tips
 half-valid-urls 
 half_valid_urls 
 tupac-sightings 
-tupac_sightings"
+tupac_sightings
+times_mixed"
 
 for catalog in $MEMORY_CATALOGS
 do


### PR DESCRIPTION
Adds support for the new datetime functions introduced in Metabase 0.45 and a small fix related to detection of types that can be suffixed with `AT TIME ZONE`.

[Metabase 0.45 blog post](https://www.metabase.com/releases/Metabase-0.45?from_page=blog#new-datetime-functions-in-the-query-builder)
