### PR TITLE
v.46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ pom.xml.asc
 .clj-kondo/
 .vscode
 */*/target/
-metabase/
+/metabase/

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ update_deps_files:
 
 test: start_trino_if_missing link_to_driver update_deps_files
 	@echo "Testing Starburst driver..."
-	cd $(makefile_dir)/metabase/; DRIVERS=starburst clojure -X:dev:drivers:drivers-dev:test
+	cd $(makefile_dir)/metabase/; DRIVERS=starburst MB_STARBURST_TEST_PORT=$(trino_port) clojure -X:dev:drivers:drivers-dev:test
 
 build: clone_metabase_if_missing update_deps_files link_to_driver front_end driver
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 
 front_end:
 	@echo "Building Front End..."
-	cd $(makefile_dir)/metabase/; yarn build && yarn build-static-viz
+	cd $(makefile_dir)/metabase/; export WEBPACK_BUNDLE=production && yarn build && yarn build-static-viz
 
 driver: update_deps_files
 	@echo "Building Starburst driver..."

--- a/app_versions.json
+++ b/app_versions.json
@@ -1,5 +1,5 @@
 {
     "trino": "384",
-    "clojure": "1.11.0.1100",
-    "metabase": "v1.45.0"
+    "clojure": "1.11.1.1208",
+    "metabase": "v1.46.0"
 }

--- a/app_versions.json
+++ b/app_versions.json
@@ -1,5 +1,5 @@
 {
     "trino": "384",
     "clojure": "1.11.1.1208",
-    "metabase": "v1.46.0"
+    "metabase": "v1.46.2"
 }

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -35,5 +35,6 @@
                               :binning                         true
                               :foreign-keys                    true
                               :datetime-diff                   true
-                              :convert-timezone                true}]
+                              :convert-timezone                true
+                              :now                             true}]
   (defmethod driver/supports? [:starburst feature] [_ _] supported?))

--- a/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
@@ -17,10 +17,7 @@
             [java-time :as t]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util :as sql.u]
-            [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honey-sql-2 :as h2x])
     (:import [java.time OffsetDateTime ZonedDateTime]))
@@ -242,37 +239,29 @@
   (let [report-zone (qp.timezone/report-timezone-id-if-supported :starburst)]
     [:from_unixtime expr (h2x/literal (or report-zone "UTC"))]))
 
-(defn- safe-datetime [x]
-  (cond
-    (nil? x) x
-    (= (type x) java.time.LocalDate) (hx/->timestamp x)
-    (= (keyword (hx/type-info->db-type (hx/type-info x))) :date) (hx/->timestamp x)
-    :else x))
+(defn- timestamp-with-time-zone? [expr]
+  (let [type (h2x/database-type expr)]
+    (and type (re-find #"(?i)^timestamp(?:\(\d+\))? with time zone$" type))))
 
-(defmethod sql.qp/->honeysql [:starburst :datetime-diff]
-  [driver [_ x y unit]]
-  (let [x (sql.qp/->honeysql driver x)
-        y (sql.qp/->honeysql driver y)
-        disallowed-types (keep
-                          (fn [v]
-                            (when-let [db-type (keyword (hx/type-info->db-type (hx/type-info v)))]
-                              (let [base-type (sql-jdbc.sync/database-type->base-type driver db-type)]
-                                (when-not (some #(isa? base-type %) [:type/Date :type/DateTime])
-                                  (name db-type)))))
-                          [x y])]
-    (when (seq disallowed-types)
-      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
-                           (pr-str disallowed-types))
-                      {:found disallowed-types
-                       :type  qp.error-type/invalid-query})))
-    (case unit
-      (:year :quarter :month :week :day)
-      (let [x-date (hsql/call :date (->AtTimeZone (safe-datetime x) (qp.timezone/results-timezone-id)))
-            y-date (hsql/call :date (->AtTimeZone (safe-datetime y) (qp.timezone/results-timezone-id)))]
-        (hsql/call :date_diff (hx/literal unit) x-date y-date))
+(defn- ->timestamp-with-time-zone [expr]
+  (if (timestamp-with-time-zone? expr)
+    expr
+    (h2x/cast timestamp-with-time-zone-db-type expr)))
 
-      (:hour :minute :second)
-      (hsql/call :date_diff (hx/literal unit) x y))))
+(defn- ->at-time-zone [expr]
+  (h2x/at-time-zone (->timestamp-with-time-zone expr) (qp.timezone/results-timezone-id)))
+
+(doseq [unit [:year :quarter :month :week :day]]
+  (defmethod sql.qp/datetime-diff [:starburst unit] [_driver unit x y]
+    [:date_diff (h2x/literal unit)
+     (h2x/->date (->at-time-zone x))
+     (h2x/->date (->at-time-zone y))]))
+
+(doseq [unit [:hour :minute :second]]
+  (defmethod sql.qp/datetime-diff [:starburst unit] [_driver unit x y]
+    [:date_diff (h2x/literal unit)
+     (->at-time-zone x)
+     (->at-time-zone y)]))
 
 (defmethod sql.qp/->honeysql [:starburst :convert-timezone]
   [driver [_ arg target-timezone source-timezone]]

--- a/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/query_processor.clj
@@ -12,9 +12,8 @@
 ;; limitations under the License.
 ;;
 (ns metabase.driver.implementation.query-processor  "Query processor implementations for Starburst driver."
-  (:require [honeysql.core :as hsql]
-            [honeysql.format :as hformat]
-            [honeysql.helpers :as hh]
+  (:require [honey.sql :as sql]
+            [honey.sql.helpers :as sql.helpers]
             [java-time :as t]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util :as sql.u]
@@ -23,11 +22,14 @@
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [tru]])
+            [metabase.util.honey-sql-2 :as h2x])
     (:import [java.time OffsetDateTime ZonedDateTime]))
 
 (def ^:private ^:const timestamp-with-time-zone-db-type "timestamp with time zone")
+
+(defmethod sql.qp/honey-sql-version :starburst
+  [_driver]
+  2)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Misc Implementations                                                       |
@@ -35,32 +37,43 @@
 
 (defmethod sql.qp/->float :starburst
   [_ value]
-  (hx/cast :double value))
+  (h2x/cast :double value))
 
-(defmethod hformat/fn-handler (u/qualified-name ::mod)
-  [_ x y]
-  ;; Trino mod is a function like mod(x, y) rather than an operator like x mod y
-  (format "mod(%s, %s)" (hformat/to-sql x) (hformat/to-sql y)))
+
+(defn- format-mod
+  [_fn [x y]]
+  (let [[x-sql & x-args] (sql/format-expr x {:nested true})
+        [y-sql & y-args] (sql/format-expr y {:nested true})]
+    (into [(format "mod(%s, %s)" x-sql y-sql)]
+          cat
+          [x-args y-args])))
+
+(sql/register-fn! ::mod #'format-mod)
+
 
 (defmethod sql.qp/add-interval-honeysql-form :starburst
   [_ hsql-form amount unit]
-  (hsql/call :date_add (hx/literal unit) amount hsql-form))
+  (let [type-info   (h2x/type-info hsql-form)
+        out-form [:date_add (h2x/literal unit) [:inline amount] hsql-form]]
+  (if (some? type-info)
+    (h2x/with-type-info out-form type-info)
+    out-form)))
 
 (defmethod sql.qp/apply-top-level-clause [:starburst :page]
   [_ _ honeysql-query {{:keys [items page]} :page}]
   (let [offset (* (dec page) items)]
     (if (zero? offset)
       ;; if there's no offset we can simply use limit
-      (hh/limit honeysql-query items)
+      (sql.helpers/limit honeysql-query items)
       ;; if we need to do an offset we have to do nesting to generate a row number and where on that
       (let [over-clause (format "row_number() OVER (%s)"
-                                (first (hsql/format (select-keys honeysql-query [:order-by])
+                                (first (sql/format (select-keys honeysql-query [:order-by])
                                                     :allow-dashed-names? true
                                                     :quoting :ansi)))]
-        (-> (apply hh/select (map last (:select honeysql-query)))
-            (hh/from (hh/merge-select honeysql-query [(hsql/raw over-clause) :__rownum__]))
-            (hh/where [:> :__rownum__ offset])
-            (hh/limit items))))))
+        (-> (apply sql.helpers/select (map last (:select honeysql-query)))
+            (sql.helpers/from (sql.helpers/select honeysql-query [[:raw over-clause] :__rownum__]))
+            (sql.helpers/where [:> :__rownum__ offset])
+            (sql.helpers/limit items))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Temporal Casting                                                       |
@@ -68,25 +81,16 @@
 
 (defmethod sql.qp/cast-temporal-string [:starburst :Coercion/YYYYMMDDHHMMSSString->Temporal]
   [_ _coercion-strategy expr]
-  (hsql/call :date_parse expr (hx/literal "%Y%m%d%H%i%s")))
+  [:date_parse expr (h2x/literal "%Y%m%d%H%i%s")])
 
 (defmethod sql.qp/cast-temporal-byte [:starburst :Coercion/YYYYMMDDHHMMSSBytes->Temporal]
   [driver _coercion-strategy expr]
   (sql.qp/cast-temporal-string driver :Coercion/YYYYMMDDHHMMSSString->Temporal
-                               (hsql/call :from_utf8 expr)))
+                               [:from_utf8 expr]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Date Truncation                                                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+
-
-(defrecord AtTimeZone
-  ;; record type to support applying Starburst's `AT TIME ZONE` operator to an expression
-           [expr zone]
-  hformat/ToSql
-  (to-sql [_]
-    (format "%s AT TIME ZONE %s"
-            (hformat/to-sql expr)
-            (hformat/to-sql (hx/literal zone)))))
 
 (defn- in-report-zone
   "Returns a HoneySQL form to interpret the `expr` (a temporal value) in the current report time zone, via Trino's
@@ -94,15 +98,15 @@
   [expr]
   (let [report-zone (qp.timezone/report-timezone-id-if-supported :starburst)
         ;; if the expression itself has type info, use that, or else use a parent expression's type info if defined
-        type-info   (hx/type-info expr)
-        db-type     (hx/type-info->db-type type-info)]
+        type-info   (h2x/type-info expr)
+        db-type     (h2x/type-info->db-type type-info)]
     (if (and ;; AT TIME ZONE is only valid on these Trino types; if applied to something else (ex: `date`), then
              ;; an error will be thrown by the query analyzer
          (and db-type (re-find #"(?i)^time(?:stamp)?(?:\(\d+\))?(?: with time zone)?$" db-type))
              ;; if one has already been set, don't do so again
          (not (::in-report-zone? (meta expr)))
          report-zone)
-      (-> (hx/with-database-type-info (->AtTimeZone expr report-zone) timestamp-with-time-zone-db-type)
+      (-> (h2x/with-database-type-info (h2x/at-time-zone expr report-zone) timestamp-with-time-zone-db-type)
           (vary-meta assoc ::in-report-zone? true))
       expr)))
 
@@ -114,76 +118,76 @@
 
 (defmethod sql.qp/date [:starburst :second-of-minute]
   [_ _ expr]
-  (hsql/call :second (in-report-zone expr)))
+  [:second (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :minute]
   [_ _ expr]
-  (hsql/call :date_trunc (hx/literal :minute) (in-report-zone expr)))
+  [:date_trunc (h2x/literal :minute) (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :minute-of-hour]
   [_ _ expr]
-  (hsql/call :minute (in-report-zone expr)))
+  [:minute (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :hour]
   [_ _ expr]
-  (hsql/call :date_trunc (hx/literal :hour) (in-report-zone expr)))
+  [:date_trunc (h2x/literal :hour) (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :hour-of-day]
   [_ _ expr]
-  (hsql/call :hour (in-report-zone expr)))
+  [:hour (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :day]
   [_ _ expr]
-  (hsql/call :date (in-report-zone expr)))
+  [:date (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :day-of-week]
   [_ _ expr]
-  (sql.qp/adjust-day-of-week :starburst (hsql/call :day_of_week (in-report-zone expr))))
+  (sql.qp/adjust-day-of-week :starburst [:day_of_week (in-report-zone expr)]))
 
 (defmethod sql.qp/date [:starburst :day-of-month]
   [_ _ expr]
-  (hsql/call :day (in-report-zone expr)))
+  [:day (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :day-of-year]
   [_ _ expr]
-  (hsql/call :day_of_year (in-report-zone expr)))
+  [:day_of_year (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :week]
   [_ _ expr]
-  (sql.qp/adjust-start-of-week :starburst (partial hsql/call :date_trunc (hx/literal :week)) (in-report-zone expr)))
+  (sql.qp/adjust-start-of-week :starburst (fn [expr] [:date_trunc (h2x/literal :week) (in-report-zone expr)]) expr))
 
 (defmethod sql.qp/date [:starburst :week-of-year-iso]
   [_ _ expr]
-  (hsql/call :week (in-report-zone expr)))
+  [:week (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :month]
   [_ _ expr]
-  (hsql/call :date_trunc (hx/literal :month) (in-report-zone expr)))
+  [:date_trunc (h2x/literal :month) (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :month-of-year]
   [_ _ expr]
-  (hsql/call :month (in-report-zone expr)))
+  [:month (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :quarter]
   [_ _ expr]
-  (hsql/call :date_trunc (hx/literal :quarter) (in-report-zone expr)))
+  [:date_trunc (h2x/literal :quarter) (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :quarter-of-year]
   [_ _ expr]
-  (hsql/call :quarter (in-report-zone expr)))
+  [:quarter (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :year]
   [_ _ expr]
-  (hsql/call :date_trunc (hx/literal :year) (in-report-zone expr)))
+  [:date_trunc (h2x/literal :year) (in-report-zone expr)])
 
 (defmethod sql.qp/date [:starburst :year-of-era]
   [_ _ expr]
-  (hsql/call :year (in-report-zone expr)))
+  [:year (in-report-zone expr)])
 
 (defmethod sql.qp/current-datetime-honeysql-form :starburst
   [_]
   ;; the current_timestamp in Starburst returns a `timestamp with time zone`, so this needs to be overridden
-  (hx/with-type-info :%now {::hx/database-type timestamp-with-time-zone-db-type}))
+  (h2x/with-type-info :%now {::h2x/database-type timestamp-with-time-zone-db-type}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Custom HoneySQL Clause Impls                                          |
@@ -191,24 +195,24 @@
 
 (defmethod sql.qp/->honeysql [:starburst Boolean]
   [_ bool]
-  (hsql/raw (if bool "TRUE" "FALSE")))
+  [:raw (if bool "TRUE" "FALSE")])
 
 (defmethod sql.qp/->honeysql [:starburst :regex-match-first]
   [driver [_ arg pattern]]
-  (hsql/call :regexp_extract (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)))
+  [:regexp_extract (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)])
 
 (defmethod sql.qp/->honeysql [:starburst :median]
   [driver [_ arg]]
-  (hsql/call :approx_percentile (sql.qp/->honeysql driver arg) 0.5))
+  [:approx_percentile (sql.qp/->honeysql driver arg) 0.5])
 
 (defmethod sql.qp/->honeysql [:starburst :percentile]
   [driver [_ arg p]]
-  (hsql/call :approx_percentile (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver p)))
+  [:approx_percentile (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver p)])
 
 (defmethod sql.qp/->honeysql [:starburst :log]
   [driver [_ field]]
   ;; recent Trino versions have a `log10` function (not `log`)
-  (hsql/call :log10 (sql.qp/->honeysql driver field)))
+  [:log10 (sql.qp/->honeysql driver field)])
 
 (defmethod sql.qp/->honeysql [:starburst :count-where]
   [driver [_ pred]]
@@ -219,24 +223,24 @@
 (defmethod sql.qp/->honeysql [:starburst :time]
   [_ [_ t]]
   ;; Convert t to locale time, then format as sql. Then add cast.
-  (hx/cast :time (u.date/format-sql (t/local-time t))))
+  (h2x/cast :time (u.date/format-sql (t/local-time t))))
 
 (defmethod sql.qp/->honeysql [:starburst ZonedDateTime]
   [_ ^ZonedDateTime t]
   ;; use the Trino cast to `timestamp with time zone` operation to interpret in the correct TZ, regardless of
   ;; connection zone
-  (hx/cast timestamp-with-time-zone-db-type (u.date/format-sql t)))
+  (h2x/cast timestamp-with-time-zone-db-type (u.date/format-sql t)))
 
 (defmethod sql.qp/->honeysql [:starburst OffsetDateTime]
   [_ ^OffsetDateTime t]
   ;; use the Trino cast to `timestamp with time zone` operation to interpret in the correct TZ, regardless of
   ;; connection zone
-  (hx/cast timestamp-with-time-zone-db-type (u.date/format-sql t)))
+  (h2x/cast timestamp-with-time-zone-db-type (u.date/format-sql t)))
 
 (defmethod sql.qp/unix-timestamp->honeysql [:starburst :seconds]
   [_ _ expr]
   (let [report-zone (qp.timezone/report-timezone-id-if-supported :starburst)]
-    (hsql/call :from_unixtime expr (hx/literal (or report-zone "UTC")))))
+    [:from_unixtime expr (h2x/literal (or report-zone "UTC"))]))
 
 (defn- safe-datetime [x]
   (cond
@@ -274,11 +278,11 @@
   [driver [_ arg target-timezone source-timezone]]
   (let [expr         (sql.qp/->honeysql driver (cond-> arg
                                                  (string? arg) u.date/parse))
-        with_timezone? (hx/is-of-type? expr #"(?i)^timestamp(?:\(\d+\))? with time zone$")
+        with_timezone? (h2x/is-of-type? expr #"(?i)^timestamp(?:\(\d+\))? with time zone$")
         _ (sql.u/validate-convert-timezone-args with_timezone? target-timezone source-timezone)
-        expr (hsql/call :at_timezone
+        expr [:at_timezone
                         (if with_timezone?
                           expr
-                          (hsql/call :with_timezone expr (or source-timezone (qp.timezone/results-timezone-id))))
-                        target-timezone)]
-    (hx/with-database-type-info (hx/->timestamp expr) "timestamp")))
+                          [:with_timezone expr (or source-timezone (qp.timezone/results-timezone-id))])
+                        target-timezone]]
+    (h2x/with-database-type-info (h2x/->timestamp expr) "timestamp")))

--- a/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -85,9 +85,9 @@
                           [3 "The Apple Pan"]
                           [4 "Wurstküche"]
                           [5 "Brite Spot Family Restaurant"]]
-                         (->> (metadata-queries/table-rows-sample (Table (mt/id :venues))
-                                                                  [(Field (mt/id :venues :id))
-                                                                   (Field (mt/id :venues :name))]
+                         (->> (metadata-queries/table-rows-sample (db/select-one Table :id (mt/id :venues))
+                                                                  [(db/select-one Field :id (mt/id :venues :id))
+                                                                   (db/select-one Field :id (mt/id :venues :name))]
                                                                   (constantly conj))
                               (sort-by first)
                               (take 5))))))

--- a/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -36,20 +36,20 @@
 
 (deftest describe-database-test
   (mt/test-driver :starburst
-                  (is (= {:tables #{{:name "categories" :schema "default"}
-                                    {:name "venues" :schema "default"}
-                                    {:name "checkins" :schema "default"}
-                                    {:name "users" :schema "default"}}}
+                  (is (= {:tables #{{:name "test_data_categories" :schema "default"}
+                                    {:name "test_data_venues" :schema "default"}
+                                    {:name "test_data_checkins" :schema "default"}
+                                    {:name "test_data_users" :schema "default"}}}
                          (-> (driver/describe-database :starburst (mt/db))
-                             (update :tables (comp set (partial filter (comp #{"categories"
-                                                                               "venues"
-                                                                               "checkins"
-                                                                               "users"}
+                             (update :tables (comp set (partial filter (comp #{"test_data_categories"
+                                                                               "test_data_venues"
+                                                                               "test_data_checkins"
+                                                                               "test_data_users"}
                                                                              :name)))))))))
 
 (deftest describe-table-test
   (mt/test-driver :starburst
-                  (is (= {:name   "venues"
+                  (is (= {:name   "test_data_venues"
                           :schema "default"
                           :fields #{{:name          "name",
                        ;; for HTTP based Starburst driver, this is coming back as varchar(255)
@@ -146,8 +146,8 @@
                                               :filter      [:= $name "wow"]})]
                     (testing "The native query returned in query results should use user-friendly splicing"
                       (is (= (str "SELECT count(*) AS \"count\" "
-                                  "FROM \"default\".\"venues\" "
-                                  "WHERE \"default\".\"venues\".\"name\" = 'wow'")
+                                  "FROM \"default\".\"test_data_venues\" "
+                                  "WHERE \"default\".\"test_data_venues\".\"name\" = 'wow'")
                              (:query (qp/compile-and-splice-parameters query))
                              (-> (qp/process-query query) :data :native_form :query)))))))
 

--- a/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -15,7 +15,6 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.test :refer :all]
-            [honeysql.core :as hsql]
             [java-time :as t]
             [metabase.api.database :as api.database]
             [metabase.db.metadata-queries :as metadata-queries]
@@ -98,7 +97,7 @@
     (is (= {:select ["name" "id"]
             :from   [{:select   [[:default.categories.name "name"]
                                  [:default.categories.id "id"]
-                                 [(hsql/raw "row_number() OVER (ORDER BY \"default\".\"categories\".\"id\" ASC)")
+                                 [[:raw "row_number() OVER (ORDER BY default.categories.id ASC)"]
                                   :__rownum__]]
                       :from     [:default.categories]
                       :order-by [[:default.categories.id :asc]]}]
@@ -145,7 +144,7 @@
                                              {:aggregation [[:count]]
                                               :filter      [:= $name "wow"]})]
                     (testing "The native query returned in query results should use user-friendly splicing"
-                      (is (= (str "SELECT count(*) AS \"count\" "
+                      (is (= (str "SELECT COUNT(*) AS \"count\" "
                                   "FROM \"default\".\"test_data_venues\" "
                                   "WHERE \"default\".\"test_data_venues\".\"name\" = 'wow'")
                              (:query (qp/compile-and-splice-parameters query))

--- a/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -25,7 +25,8 @@
             [metabase.test.data.sql-jdbc.execute :as execute]
             [metabase.test.data.sql-jdbc.load-data :as load-data]
             [metabase.test.data.sql.ddl :as ddl]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [metabase.util.log :as log])
   (:import [java.sql Connection DriverManager PreparedStatement]))
 
 ;; JDBC SQL
@@ -114,9 +115,8 @@
         (try
           (with-open [^PreparedStatement stmt (.prepareStatement conn sql)]
             (sql-jdbc.execute/set-parameters! driver stmt params)
-            (let [tbl-nm        ((comp last :components) (into {} table-identifier))
-                  rows-affected (.executeUpdate stmt)]
-              (println (format "[%s] Inserted %d rows into starburst table %s." driver rows-affected tbl-nm))))
+            (let [rows-affected (.executeUpdate stmt)]
+              (log/infof "[%s] Inserted %d rows into starburst table %s" driver rows-affected table-identifier)))
           (catch Throwable e
             (throw (ex-info (format "[%s] Error executing SQL: %s" driver (ex-message e))
                             {:driver driver, :sql sql, :params params}

--- a/resources/docker/trino/entrypoint.sh
+++ b/resources/docker/trino/entrypoint.sh
@@ -9,53 +9,12 @@ if [ -f /tmp/trino-initialized ]; then
 fi
 
 TRINO_CATALOG_DIR="/etc/trino/catalog"
+TEST_CATALOG="test_data"
 
-# Catalogs required to run metabase tests that all use the memory connector
-MEMORY_CATALOGS="a-checkin-every-15-seconds 
-memory 
-a-checkin-every-86400-seconds 
-office_checkins 
-a-checkin-every-900-seconds 
-places-cam-likes 
-a_checkin_every_15_seconds 
-places_cam_likes 
-a_checkin_every_86400_seconds 
-postgres 
-a_checkin_every_900_seconds 
-sad-toucan-incidents 
-airports 
-sad_toucan_incidents 
-attempted_murders 
-sample_database 
-avian-singles 
-sample_dataset 
-avian_singles 
-string_times 
-checkins test-data-with-time 
-checkins_interval_15 
-test-data 
-checkins_interval_86400 
-test_data 
-checkins_interval_900 
-test_data_with_time 
-daily_bird_counts 
-test_data_with_timezones 
-geographical-tips 
-toucan_microsecond_incidents 
-geographical_tips 
-half-valid-urls 
-half_valid_urls 
-tupac-sightings 
-tupac_sightings
-times_mixed"
-
-for catalog in $MEMORY_CATALOGS
-do
-log "Set up catalog file ${TRINO_CATALOG_DIR}/$catalog"
-cat << EOF >> "${TRINO_CATALOG_DIR}/${catalog}.properties"
+log "Set up catalog file ${TRINO_CATALOG_DIR}/$TEST_CATALOG"
+cat << EOF >> "${TRINO_CATALOG_DIR}/${TEST_CATALOG}.properties"
 connector.name=memory
 EOF
-done
 
 touch /tmp/trino-initialized
 


### PR DESCRIPTION
### Notable Changes

#### Updated tests to use same catalog [(c292b9a)](https://github.com/starburstdata/metabase-driver/commit/c292b9aa766eac6ca751f7ad34c079d6c0cc7005)

This commit is same as the [changes](https://github.com/metabase/metabase/commit/5a80e561019b256674959d629afb009517f835c4) made to `presto-jdbc` driver at metabase repo.  Detected that few of the new tests tries to create a dynamically named database so this change might be mandatory for future. (I forgot where the mentioned test is located, I will edit here later linking the related file.)

#### Migrated to Honey SQL 2 [(8c3a641)](https://github.com/starburstdata/metabase-driver/commit/8c3a64169c0365b661dca5c28251fd53a4dc30eb)

[Reference](https://www.metabase.com/docs/latest/developers-guide/driver-changelog#honey-sql-2). Should close #88. 

#### Updated datatime_diff implementation to use the new multimethod [(f49d892)](https://github.com/starburstdata/metabase-driver/commit/f49d892804b40edb993c1cf21a131ee342b76a09)

From [driver-changelog](https://github.com/metabase/metabase/blob/master/docs/developers-guide/driver-changelog.md#metabase-0460)
> The multimethod metabase.driver.sql.query-processor/datetime-diff has been added. This method is used by implementations of ->honeysql for the :datetime-diff clause. It is recommended to implement this if you want to use the default SQL implementation of ->honeysql for the :datetime-diff, which includes validation of argument types across all units.

#### Bumped metabase and clojure versions [(8a45d0b)](https://github.com/starburstdata/metabase-driver/commit/8a45d0bce40741d1c3c5d8b0309604e76fda3a04)

Bumped clojure version according to [prepare-backend.yml](https://github.com/metabase/metabase/blob/v1.46.0/.github/actions/prepare-backend/action.yml) github action in metabase repository.

