### PR TITLE
Fix datetime filter issue with Metabase 0.47

### DIFF
--- a/.github/actions/init-dependencies/action.yml
+++ b/.github/actions/init-dependencies/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: "Use Node.js"
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - name: Cache Clojure install
       id: cache-clojure
       uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 
 front_end:
 	@echo "Building Front End..."
-	cd $(makefile_dir)/metabase/; export WEBPACK_BUNDLE=production && yarn build && yarn build-static-viz
+	cd $(makefile_dir)/metabase/; export WEBPACK_BUNDLE=production && yarn build-release && yarn build-static-viz
 
 driver: update_deps_files
 	@echo "Building Starburst driver..."

--- a/app_versions.json
+++ b/app_versions.json
@@ -1,5 +1,5 @@
 {
     "trino": "426",
-    "clojure": "1.11.1.1208",
-    "metabase": "v1.46.4"
+    "clojure": "1.11.1.1262",
+    "metabase": "v1.47.2"
 }

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -37,4 +37,4 @@
                               :datetime-diff                   true
                               :convert-timezone                true
                               :now                             true}]
-  (defmethod driver/supports? [:starburst feature] [_ _] supported?))
+  (defmethod driver/database-supports? [:starburst feature] [_ _ _] supported?))

--- a/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -30,6 +30,7 @@
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
+            [toucan2.tools.with-temp :as t2.with-temp]
             [toucan.db :as db]))
 
 (use-fixtures :once (fixtures/initialize :db))
@@ -188,7 +189,7 @@
                                      (format "DROP SCHEMA IF EXISTS %s" s)
                                      (format "CREATE SCHEMA %s" s)
                                      (format "CREATE TABLE %s.%s (pk INTEGER, val1 VARCHAR(512))" s t)])
-                      (mt/with-temp Database [db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details with-schema}]
+                      (t2.with-temp/with-temp [Database db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details with-schema}]
                         (mt/with-db db
             ;; same as test_data, but with schema, so should NOT pick up venues, users, etc.
                           (sync/sync-database! db)
@@ -307,7 +308,7 @@
             :roles                        "sysadmin"
             :ssl                          false
             :impersonation                true}]
-              (mt/with-temp Database [db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details details}]
+              (t2.with-temp/with-temp [Database db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details details}]
               (mt/with-db db
               (qp/process-query
                 {:database     (mt/id)
@@ -325,7 +326,7 @@
               :roles                        "sysadmin"
               :ssl                          false
               :impersonation                true}]
-                (mt/with-temp Database [db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details details}]
+                (t2.with-temp/with-temp [Database db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details details}]
                 (mt/with-db db
                 (qp/process-query
                   {:database     (mt/id)
@@ -343,7 +344,7 @@
               :roles                        "sysadmin"
               :ssl                          false
               :impersonation                false}]
-                (mt/with-temp Database [db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details details}]
+                (t2.with-temp/with-temp [Database db {:engine :starburst, :name "Temp Trino JDBC Schema DB", :details details}]
                 (mt/with-db db
                 (qp/process-query
                   {:database     (mt/id)


### PR DESCRIPTION
Even though this was not documented, Metabase 0.47 changed the way `report-timezone-id-if-supported` is called (it now needs a second argument)

Based on what I could find online (https://github.com/metabase/metabase/blob/master/src/metabase/driver/sql_jdbc/execute.clj) and confirmed by Metabase, the code was modified accordingly.