### PR TITLE
Remote deprecated methods

### DIFF
--- a/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/drivers/starburst/src/metabase/driver/starburst.clj
@@ -17,7 +17,7 @@
                         [metabase.driver.sql-jdbc.execute.legacy-impl :as sql-jdbc.legacy]))
 (driver/register! :starburst, :parent #{::sql-jdbc.legacy/use-legacy-classes-for-read-and-set})
  
-(prefer-method driver/supports? [:starburst :set-timezone] [:sql-jdbc :set-timezone])
+(prefer-method driver/database-supports? [:starburst :set-timezone] [:sql-jdbc :set-timezone])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  Load implemetation files                                      |


### PR DESCRIPTION
Removing methods which are deprecated in Metabase 0.47.0 and will be removed in 0.50.0:

- `sql-jdbc.execute/connection-with-timezone`: the changes to make are documented in https://github.com/metabase/metabase/pull/22166.
- `driver/supports?`: this was mostly done in the previous PR, just removing the last mention