### PR TITLE
Add query remarks

### DIFF
--- a/drivers/starburst/src/metabase/driver/implementation/execute.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/execute.clj
@@ -153,7 +153,7 @@
 (defn impersonate-user
   [conn]
   (if
-    (clojure.string/includes? (.getProperty (.getClientInfo conn) "ClientInfo") "impersonate:true")
+    (clojure.string/includes? (.getProperty (.getClientInfo conn) "ClientInfo" "") "impersonate:true")
     (let [email (get (deref api/*current-user*) :email)]
       (.setSessionUser (.unwrap conn TrinoConnection) email))
     nil))
@@ -161,7 +161,7 @@
 (defn remove-impersonation
   [conn]
   (if
-    (clojure.string/includes? (.getProperty (.getClientInfo conn) "ClientInfo") "impersonate:true")
+    (clojure.string/includes? (.getProperty (.getClientInfo conn) "ClientInfo" "") "impersonate:true")
     (.clearSessionUser (.unwrap conn TrinoConnection))
     nil))
 

--- a/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/drivers/starburst/src/metabase/driver/starburst.clj
@@ -14,10 +14,26 @@
 (ns metabase.driver.starburst
   "Starburst driver."
   (:require [metabase.driver :as driver]
-                        [metabase.driver.sql-jdbc.execute.legacy-impl :as sql-jdbc.legacy]))
+            [metabase.query-processor.util :as qp.util]
+            [metabase.public-settings :as public-settings]
+            [metabase.driver.sql-jdbc.execute.legacy-impl :as sql-jdbc.legacy]))
 (driver/register! :starburst, :parent #{::sql-jdbc.legacy/use-legacy-classes-for-read-and-set})
  
 (prefer-method driver/database-supports? [:starburst :set-timezone] [:sql-jdbc :set-timezone])
+
+(defn format-field
+  [name value]
+  (if (nil? value)
+    ""
+    (str " " name ": " value)))
+
+(defmethod qp.util/query->remark :starburst
+  [_ {{:keys [card-id dashboard-id]} :info, :as query}]
+  (str
+    (qp.util/default-query->remark query)
+    (format-field "accountID" (public-settings/site-uuid))
+    (format-field "dashboardID" dashboard-id)
+    (format-field "cardID" card-id)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  Load implemetation files                                      |


### PR DESCRIPTION
When executing a query, Metabase adds a comment providing the user ID, query type and hash:

```
PREPARE statement3 FROM -- Metabase:: userID: 1 queryType: MBQL queryHash: a5cd01e49cc4cef75ee341f2249ea177b7fefe3d71762318caa3b7a6d76d9cd0
SELECT "default"."customer"."custkey" FROM "default"."customer"
```

This PR adds extra information as it's already done with Redshift (https://github.com/metabase/metabase/blob/dc676e1e649249c4ddb2ff9ee3752682596b0f23/modules/drivers/redshift/src/metabase/driver/redshift.clj#L312). It adds the account ID, Dashboard ID and when card ID available:

```
PREPARE statement3 FROM -- Metabase:: userID: 1 queryType: native queryHash: e80d81488b5f52789240a8be468983ab5638ef272b524b5e7c6fb9830beeb201 accountID: d578dddb-cbda-41b2-b00d-599e445dac37
SELECT "default"."customer"."custkey" FROM "default"."customer"
```

```
PREPARE statement4 FROM -- Metabase:: userID: 1 queryType: MBQL queryHash: b2ad15ab0ef360e068ec906b53fdecfd8be58a1fde061225d484c0b3f2bc3301 accountID: d578dddb-cbda-41b2-b00d-599e445dac37 dashboardID: 1 cardID: 2
SELECT "default"."customer"."custkey" FROM "default"."customer"
```