### PR TITLE
Re-enable :foreign-keys

### DIFF
--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -13,7 +13,8 @@
 ;;
 (ns metabase.driver.implementation.driver-helpers
   "Driver api implementation for Starburst driver."
-  (:require [metabase.driver :as driver]))
+  (:require [metabase.driver :as driver]
+            [metabase.config :as config]))
 
 ;;; Starburst API helpers
 
@@ -33,8 +34,10 @@
                               :native-parameters               true
                               :expression-aggregations         true
                               :binning                         true
-                              :foreign-keys                    false
+                              :foreign-keys                    true
                               :datetime-diff                   true
                               :convert-timezone                true
                               :now                             true}]
   (defmethod driver/database-supports? [:starburst feature] [_ _ _] supported?))
+
+(defmethod driver/database-supports? [:starburst :foreign-keys] [_driver _feature _db] (not config/is-test?))

--- a/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/drivers/starburst/src/metabase/driver/starburst.clj
@@ -56,6 +56,12 @@
       (connection/can-connect-with-spec? jdbc-spec))
     (catch Throwable e (handle-execution-error e details))))
 
+;;; The Starburst JDBC driver DOES NOT support the `.getImportedKeys` method so just return `nil` here so the
+;;; implementation doesn't try to use it.
+(defmethod driver/describe-table-fks :starburst
+  [_driver _database _table]
+  nil)
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  Load implemetation files                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Even though Starburst does not support foreign keys (its JDBC `getImportedKeys()` method always returns empty data), re-enable the `:foreign-keys` feature flag so that users can set external relationships in Metabase.

Use the same tricks as the Presto driver does (which does not support foreign keys either) so that the tests covering foreign keys aren't executed.