### PR TITLE
Enable call to PreparedStatement's cancel

### DIFF
--- a/drivers/starburst/src/metabase/driver/implementation/execute.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/execute.clj
@@ -227,7 +227,8 @@
           (setLong [index val] (.setLong stmt index val))
           (setFloat [index val] (.setFloat stmt index val))
           (setDouble [index val] (.setDouble stmt index val))
-          (close [] (.close stmt)))]
+          (close [] (.close stmt))
+          (cancel [] (.cancel stmt)))]
     (sql-jdbc.execute/set-parameters! driver ps params)
     ps))
 

--- a/drivers/starburst/src/metabase/driver/implementation/execute.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/execute.clj
@@ -250,7 +250,8 @@
           rs)
           (catch Throwable e (handle-execution-error e))))
     (setMaxRows [nb] (.setMaxRows stmt nb))
-    (close [] (.close stmt))))
+    (close [] (.close stmt))
+    (cancel [] (.cancel stmt))))
 
 (defmethod sql-jdbc.execute/prepared-statement :starburst
   [driver ^Connection conn ^String sql params]
@@ -295,7 +296,8 @@
             (finally (remove-impersonation conn))))
       (getResultSet [] (.getResultSet stmt))
       (setMaxRows [nb] (.setMaxRows stmt nb))
-      (close [] (.close stmt)))))
+      (close [] (.close stmt))
+      (cancel [] (.cancel stmt)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Prepared Statement Substitutions                                      |


### PR DESCRIPTION
Metabase calls PreparedStatement's `.cancel`  method in order to stop any queries cancelled by the user as shown here
https://github.com/metabase/metabase/blob/ceacccd0b1aa4dc51c0c88228f91922fe6934ec0/src/metabase/driver/sql_jdbc/execute.clj#L735

We observed that it failed to cancel with `java.lang.UnsupportedOperationException` which looks like due to `cancel` function not currently proxied.

Any feedback is appreciated as I'm not familiar with clojure and this is my first interaction with Metabase codebase.

Thank you