### PR TITLE
128 upgrade to metabase 152

### DIFF
--- a/.github/actions/init-dependencies/action.yml
+++ b/.github/actions/init-dependencies/action.yml
@@ -20,7 +20,7 @@ inputs:
   node-version:
     description: "Node version to setup"
     required: false
-    default: "16.x"
+    default: "18.x"
   clojure-version:
     description: "Clojure version to setup"
     required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
           java-version: ${{ matrix.runners.java_version }}
           java-architecture: ${{ matrix.runners.architecture }}
           clojure-version: ${{ env.CLOJURE_VERSION }}
+      - name: Initialize Metabase
+        run: |
+          cd metabase |
+          yarn build-static-viz |
+          cd ..
       - name: Build
         run: |
           make build

--- a/Makefile
+++ b/Makefile
@@ -11,36 +11,36 @@ trino_port := 8082
 is_trino_started := $(shell curl --fail --silent --insecure http://localhost:$(trino_port)/v1/info | jq '.starting')
 
 clone_metabase_if_missing:
-ifeq ($(wildcard $(makefile_dir)/metabase/.),)
+ifeq ($(wildcard $(makefile_dir)metabase/.),)
 	@echo "Did not find metabase repo, cloning version $(metabase_version)..."; git clone -b $(metabase_version) --depth 1 https://github.com/metabase/metabase.git
 else
 	@echo "Found metabase repo, skipping initialization."
 endif
 
 checkout_latest_metabase_tag: clone_metabase_if_missing clean
-	cd $(makefile_dir)/metabase; git fetch --all --tags;
-	$(eval latest_metabase_version=$(shell cd $(makefile_dir)/metabase; git tag | egrep 'v[0-9]+\.[0-9]+\.[0-9]+' | sort | tail -n 1))
+	cd $(makefile_dir)metabase; git fetch --all --tags;
+	$(eval latest_metabase_version=$(shell cd $(makefile_dir)metabase; git tag | egrep 'v[0-9]+\.[0-9]+\.[0-9]+' | sort | tail -n 1))
 	@echo "Checking out latest metabase tag: $(latest_metabase_version)"
-	cd $(makefile_dir)/metabase/modules/drivers && git checkout $(latest_metabase_version);
+	cd $(makefile_dir)metabase/modules/drivers && git checkout $(latest_metabase_version);
 	sed -i.bak 's/metabase\": \".*\"/metabase\": \"$(latest_metabase_version)\"/g' app_versions.json; rm  ./app_versions.json.bak
 
 start_trino_if_missing:
 ifeq ($(is_trino_started),)
 	@echo "Trino not started, starting using version $(trino_version)...";
-	cd $(makefile_dir)/resources/docker/trino; docker build -t trino-metabase-test . --build-arg version=$(trino_version); docker run --rm -d  -p $(trino_port):8080/tcp trino-metabase-test:latest
+	cd $(makefile_dir)resources/docker/trino; docker build -t trino-metabase-test . --build-arg version=$(trino_version); docker run --rm -d  -p $(trino_port):8080/tcp trino-metabase-test:latest
 else
 	@echo "Trino started, skipping initialization."
 endif
 
 clean:
 	@echo "Force cleaning Metabase repo..."
-	cd $(makefile_dir)/metabase/modules/drivers && git reset --hard && git clean -f
+	cd $(makefile_dir)metabase/modules/drivers && git reset --hard && git clean -f
 	@echo "Checking out metabase at: $(metabase_version)"
-	cd $(makefile_dir)/metabase/modules/drivers && git fetch --all --tags && git checkout $(metabase_version);
+	cd $(makefile_dir)metabase/modules/drivers && git fetch --all --tags && git checkout $(metabase_version);
 
 link_to_driver:
-ifeq ($(wildcard $(makefile_dir)/metabase/modules/drivers/starburst/src),)
-	@echo "Adding link to driver..."; ln -s ../../../drivers/starburst $(makefile_dir)/metabase/modules/drivers
+ifeq ($(wildcard $(makefile_dir)metabase/modules/drivers/starburst/src),)
+	@echo "Adding link to driver..."; ln -s ../../../drivers/starburst $(makefile_dir)metabase/modules/drivers
 else
 	@echo "Driver found, skipping linking."
 endif
@@ -48,43 +48,45 @@ endif
 
 front_end:
 	@echo "Building Front End..."
-	cd $(makefile_dir)/metabase/; export WEBPACK_BUNDLE=production && yarn build-release && yarn build-static-viz
+	cd $(makefile_dir)metabase && yarn build-static-viz && \
+	export WEBPACK_BUNDLE=production && yarn build-release && yarn build-static-viz
 
 driver: update_deps_files
 	@echo "Building Starburst driver..."
-	cd $(makefile_dir)/metabase/; ./bin/build-driver.sh starburst
+	cd $(makefile_dir)metabase/; ./bin/build-driver.sh starburst
 
 server: 
 	@echo "Starting metabase..."
-	cd $(makefile_dir)/metabase/; clojure -M:run
+	cd $(makefile_dir)metabase/; clojure -M:run
 
 # This command adds the require starburst driver dependencies to the metabase repo.
 update_deps_files:
-	@if cd $(makefile_dir)/metabase && grep -q starburst deps.edn; \
+	@if cd $(makefile_dir)metabase && grep -q starburst deps.edn; \
 		then \
 			echo "Metabase deps file updated, skipping..."; \
 		else \
 			echo "Updating metabase deps file..."; \
-			cd $(makefile_dir)/metabase/; sed -i.bak 's/\/test\"\]\}/\/test\" \"modules\/drivers\/starburst\/test\"\]\}/g' deps.edn; \
+			cd $(makefile_dir)metabase/; sed -i.bak 's/\/test\"\]\}/\/test\" \"modules\/drivers\/starburst\/test\"\]\}/g' deps.edn; \
 	fi
 
-	@if cd $(makefile_dir)/metabase/modules/drivers && grep -q starburst deps.edn; \
+	@if cd $(makefile_dir)metabase/modules/drivers && grep -q starburst deps.edn; \
 		then \
 			echo "Metabase driver deps file updated, skipping..."; \
 		else \
 			echo "Updating metabase driver deps file..."; \
-			cd $(makefile_dir)/metabase/modules/drivers/; sed -i.bak "s/\}\}\}/\} \metabase\/starburst \{:local\/root \"starburst\"\}\}\}/g" deps.edn; \
+			cd $(makefile_dir)metabase/modules/drivers/; sed -i.bak "s/\}\}\}/\} \metabase\/starburst \{:local\/root \"starburst\"\}\}\}/g" deps.edn; \
 	fi
 
 test: start_trino_if_missing link_to_driver update_deps_files
 	@echo "Testing Starburst driver..."
-	cd $(makefile_dir)/metabase/; DRIVERS=starburst MB_STARBURST_TEST_PORT=$(trino_port) clojure -X:dev:drivers:drivers-dev:test
+	cp test_test.clj ./metabase/.clj-kondo/test/hooks/clojure/
+	cd $(makefile_dir)metabase/; DRIVERS=starburst MB_STARBURST_TEST_PORT=$(trino_port) clojure -X:dev:drivers:drivers-dev:test
 
 testOptimized: start_trino_if_missing link_to_driver update_deps_files
 	@echo "Testing Starburst driver (explicitPrepare=true)..."
-	cd $(makefile_dir)/metabase/; DRIVERS=starburst MB_STARBURST_TEST_PORT=$(trino_port) clojure -J-DexplicitPrepare=false -X:dev:drivers:drivers-dev:test
+	cd $(makefile_dir)metabase/; DRIVERS=starburst MB_STARBURST_TEST_PORT=$(trino_port) clojure -J-DexplicitPrepare=false -X:dev:drivers:drivers-dev:test
 
 build: clone_metabase_if_missing update_deps_files link_to_driver front_end driver
 
 docker-image:
-	cd $(makefile_dir)/metabase/; export MB_EDITION=ee && ./bin/build.sh && mv target/uberjar/metabase.jar bin/docker/ && docker build -t metabase-dev --build-arg MB_EDITION=ee ./bin/docker/
+	cd $(makefile_dir)metabase/; export MB_EDITION=ee && ./bin/build.sh && mv target/uberjar/metabase.jar bin/docker/ && docker build -t metabase-dev --build-arg MB_EDITION=ee ./bin/docker/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ build our `.jar` file into the correct dir, run tests, and start the local serve
 * [Clojure](https://clojure.org/guides/install_clojure)
 * [jq](https://stedolan.github.io/jq/download/)
 * [Metabase Prerequisites](https://www.metabase.com/docs/latest/developers-guide/build#install-the-prerequisites)
+* JDK 8 to 21. **JDK 22 will not work**
 
 ##### Quick Start
 Run `make build test` to build and run tests locally. If everything passes, you're good to go!
@@ -64,9 +65,9 @@ Head to actions and run the `Release` workflow entering the same the same semant
 ### Update Metabase Version
 If needed, `make checkout_latest_metabase_tag` will update Metabase to its latest tagged release. 
 
-*CAUTION*: the Metabase test file `metabase/test/metabase/driver_test.clj` is overridden by a modified version on the root directory (see the `Makefile`). This is because two tests (`can-connect-with-destroy-db-test` and `check-can-connect-before-sync-test`) do not work with the Starburst driver as they're testing what happens when a database is deleted (which cannot happen with Starburst). So instead of adding some useless stuff to `can-connect?` for the sole purpose of satisfying tests, it was found preferable to just remove those two tests.
+*CAUTION*: the Metabase test file `./metabase/.clj-kondo/test/hooks/clojure/test_test.clj` is overridden by a modified version on the root directory (see the `Makefile`). This is because the test `check-driver-keywords-test` is not expected to work with the Starburst driver.
 
-Whenever upgrading the version of Metabase, `./driver_test.clj` should be replaced with `metabase/test/metabase/driver_test.clj` with the two offending tests removed (unless they pass or there is a clean way around them)
+Whenever upgrading the version of Metabase, `./test_test.clj` should be replaced with `./metabase/.clj-kondo/test/hooks/clojure/test_test.clj` with the `check-driver-keywords-test` test removed.
 
 ## References
 * [Encrypting Metabase Database Details](https://www.metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html)

--- a/app_versions.json
+++ b/app_versions.json
@@ -1,5 +1,5 @@
 {
     "trino": "431",
     "clojure": "1.11.1.1262",
-    "metabase": "v1.50.9"
+    "metabase": "v1.52.2.2"
 }

--- a/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
+++ b/drivers/starburst/src/metabase/driver/implementation/driver_helpers.clj
@@ -34,12 +34,10 @@
                               :native-parameters               true
                               :expression-aggregations         true
                               :binning                         true
-                              :foreign-keys                    true
+                              ::concat-non-string-args          false
                               :datetime-diff                   true
                               :convert-timezone                true
                               :connection/multiple-databases   true
                               :metadata/key-constraints        false
                               :now                             true}]
   (defmethod driver/database-supports? [:starburst feature] [_ _ _] supported?))
-
-(defmethod driver/database-supports? [:starburst :foreign-keys] [_driver _feature _db] (not config/is-test?))

--- a/drivers/starburst/test/metabase/test/data/starburst.clj
+++ b/drivers/starburst/test/metabase/test/data/starburst.clj
@@ -18,7 +18,9 @@
             [metabase.connection-pool :as connection-pool]
             [metabase.driver :as driver]
             [metabase.driver.ddl.interface :as ddl.i]
+            [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+            [metabase.driver.sql.util :as sql.u]
             [metabase.test.data.interface :as tx]
             [metabase.test.data.sql :as sql.tx]
             [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
@@ -37,8 +39,12 @@
 (defmethod tx/sorts-nil-first? :starburst [_ _] false)
 
 ;; during unit tests don't treat Trino as having FK support
-(defmethod driver/database-supports? [:starburst :foreign-keys] [_ _ _] (not config/is-test?))
 (defmethod driver/database-supports? [:starburst :set-timezone] [_ _ _] true)
+(defmethod driver/database-supports? [:starburst :test/time-type] [_ _ _] false)
+(defmethod driver/database-supports? [:starburst :test/timestamptz-type] [_ _ _] false)
+(defmethod driver/database-supports? [:starburst :test/dynamic-dataset-loading] [_ _ _] (not config/is-test?))
+(defmethod driver/database-supports? [:starburst :metabase.query-processor-test.string-extracts-test/concat-non-string-args] [_ _ _] false)
+(defmethod driver/database-supports? [:starburst :metabase.query-processor-test.alternative-date-test/yyyymmddhhss-binary-timestamps] [_ _ _] false)
 
 (doseq [[base-type db-type] {:type/BigInteger             "BIGINT"
                              :type/Boolean                "BOOLEAN"
@@ -78,66 +84,52 @@
   [& args]
   (apply execute/sequentially-execute-sql! args))
 
-(defn- load-data [dbdef tabledef]
-  ;; the JDBC driver statements fail with a cryptic status 500 error if there are too many
-  ;; parameters being set in a single statement; these numbers were arrived at empirically
-  (let [chunk-size (case (:table-name tabledef)
-                     "people" 30
-                     "reviews" 40
-                     "orders" 30
-                     "venues" 50
-                     "products" 50
-                     "cities" 50
-                     "sightings" 50
-                     "incidents" 50
-                     "checkins" 25
-                     "airport" 50
-                     100)
-        load-fn    (load-data/make-load-data-fn load-data/load-data-add-ids
-                                                (partial load-data/load-data-chunked pmap chunk-size))]
-    (load-fn :starburst dbdef tabledef)))
+(defmethod load-data/chunk-size :starburst
+  [_driver _dbdef _tabledef]
+  nil)
 
-(defmethod load-data/load-data! :starburst
-  [_ dbdef tabledef]
-  (load-data dbdef tabledef))
+(defmethod load-data/row-xform :starburst
+  [_driver _dbdef _tabledef]
+  (load-data/add-ids-xform))
 
-(defn- jdbc-spec->connection
-  "This is to work around some weird interplay between clojure.java.jdbc caching behavior of connections based on URL,
-  combined with the fact that the Trino driver apparently closes the connection when it closes a prepare statement.
-  Therefore, create a fresh connection from the DriverManager."
-  ^Connection [jdbc-spec]
-  (let [conn (:connection jdbc-spec)]
-    (locking conn
-      (if (not (.getAutoCommit conn))
-        (.setAutoCommit conn true)
-        true))
-    conn))
+(defmethod ddl/insert-rows-dml-statements :starburst
+  [driver table-identifier rows]
+  (def %rows rows)
+  (binding [driver/*compile-with-inline-parameters* true]
+    ((get-method ddl/insert-rows-dml-statements :sql-jdbc/test-extensions) driver table-identifier rows)))
 
+;;; it seems to be significantly faster to load rows in batches of 500 in parallel than to try to load all the rows in
+;;; a few giant SQL statement. It seems like batch size = 5000 is a working limit here but
 (defmethod load-data/do-insert! :starburst
-  [driver spec table-identifier row-or-rows]
-  (let [statements (ddl/insert-rows-ddl-statements driver table-identifier row-or-rows)]
-    (let [conn (jdbc-spec->connection spec)]
-      (locking conn
+  [driver ^Connection conn table-identifier rows]
+  (dorun
+   (pmap
+    (fn [rows]
+      (let [statements (ddl/insert-rows-dml-statements driver table-identifier rows)]
         (doseq [[^String sql & params] statements]
+          (assert (empty? params))
           (try
-            (with-open [^PreparedStatement stmt (.prepareStatement conn sql)]
-              (sql-jdbc.execute/set-parameters! driver stmt params)
-              (let [rows-affected (.executeUpdate stmt)]
-                (log/infof "[%s] Inserted %d rows into starburst table %s" driver rows-affected table-identifier)))
+            (with-open [stmt (.createStatement conn)]
+              (let [[_tag _identifier-type components] table-identifier
+                    table-name                         (last components)]
+                (.execute stmt sql)
+                (log/infof "[%s] Inserted %d rows into %s." driver (count rows) table-name)))
             (catch Throwable e
               (throw (ex-info (format "[%s] Error executing SQL: %s" driver (ex-message e))
-                              {:driver driver, :sql sql, :params params}
-                              e)))))))))
+                              {:driver driver, :sql sql}
+                              e)))))))
+    (partition-all 500 rows))))
 
 (defmethod sql.tx/drop-db-if-exists-sql :starburst [_ _] nil)
 (defmethod sql.tx/create-db-sql         :starburst [_ _] nil)
 
+(def ^:private ^String test-schema "default")
+
 (defmethod sql.tx/qualified-name-components :starburst
   ;; use the default schema from the in-memory connector
-  ([_ _db-name]                      [test-catalog-name "default"])
-  ([_ db-name table-name]            [test-catalog-name "default" (tx/db-qualified-table-name db-name table-name)])
-  ([_ db-name table-name field-name] [test-catalog-name "default" (tx/db-qualified-table-name db-name table-name) field-name]))
-
+  ([_ _db-name]                      [test-catalog-name test-schema])
+  ([_ db-name table-name]            [test-catalog-name test-schema (tx/db-qualified-table-name db-name table-name)])
+  ([_ db-name table-name field-name] [test-catalog-name test-schema (tx/db-qualified-table-name db-name table-name) field-name]))
 
 (defmethod sql.tx/pk-sql-type :starburst
   [_]
@@ -145,19 +137,54 @@
 
 (defmethod sql.tx/create-table-sql :starburst
   [driver dbdef tabledef]
-  ;; strip out the PRIMARY KEY stuff from the CREATE TABLE statement
-  (let [sql ((get-method sql.tx/create-table-sql :sql/test-extensions) driver dbdef tabledef)]
-    (str/replace sql #", PRIMARY KEY \([^)]+\)|NOT NULL" "")))
+  ;; Presto doesn't support NOT NULL columns
+  (let [tabledef (update tabledef :field-definitions (fn [field-defs]
+                                                       (for [field-def field-defs]
+                                                         (dissoc field-def :not-null?))))
+        ;; strip out the PRIMARY KEY stuff from the CREATE TABLE statement
+        sql      ((get-method sql.tx/create-table-sql :sql/test-extensions) driver dbdef tabledef)]
+    (str/replace sql #", PRIMARY KEY \([^)]+\)" "")))
 
-(defmethod ddl.i/format-name :starburst [_ table-or-field-name]
-  (if config/is-test?
-    table-or-field-name
-    (u/->snake_case_en table-or-field-name)))
+(defmethod ddl.i/format-name :starburst
+  [_driver table-or-field-name]
+  (str/replace table-or-field-name #"-" "_"))
 
-;; Trino doesn't support FKs, at least not adding them via DDL
+;; Presto doesn't support FKs, at least not adding them via DDL
 (defmethod sql.tx/add-fk-sql :starburst
-  [_ _ _ _]
+  [_driver _dbdef _tabledef _fielddef]
   nil)
 
-;; TODO: FIXME?
-#_(defmethod tx/has-questionable-timezone-support? :starburst [_] true)
+(defn- describe-schema-sql
+  "The SHOW TABLES statement that will list all tables for the given `catalog` and `schema`."
+  {:added "0.39.0"}
+  [driver catalog schema]
+  (str "SHOW TABLES FROM " (sql.u/quote-name driver :schema catalog schema)))
+
+(defmethod tx/dataset-already-loaded? :starburst
+  [driver dbdef]
+  ;; check and make sure the first table in the dbdef has been created.
+  (let [tabledef   (first (:table-definitions dbdef))
+        ;; table-name should be something like test_data_venues
+        table-name (tx/db-qualified-table-name (:database-name dbdef) (:table-name tabledef))
+        _          (assert (some? tabledef))
+        details    (tx/dbdef->connection-details driver :db dbdef)
+        jdbc-spec  (sql-jdbc.conn/connection-details->spec driver details)]
+    (try
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver
+       jdbc-spec
+       {:write? false}
+       (fn [^Connection conn]
+         ;; look at all the tables in the test schema.
+         (let [^String sql (#'describe-schema-sql driver test-catalog-name test-schema)]
+           (with-open [stmt (.createStatement conn)
+                       rset (.executeQuery stmt sql)]
+             (loop []
+               ;; if we see the table with the name we're looking for, we're done here; otherwise keep iterating thru
+               ;; the existing tables.
+               (cond
+                 (not (.next rset))                       false
+                 (= (.getString rset "table") table-name) true
+                 :else                                    (recur)))))))
+      (catch Throwable _e
+        false))))

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@rspack/core": "^1.1.8",
+    "@rspack/plugin-react-refresh": "^1.0.1"
+  }
+}

--- a/test_test.clj
+++ b/test_test.clj
@@ -1,0 +1,40 @@
+(ns hooks.clojure.test-test
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clj-kondo.impl.utils]
+   [clojure.edn :as edn]
+   [clojure.test :refer :all]
+   [hooks.clojure.test]))
+
+(set! *warn-on-reflection* true)
+
+(defn- deftest-warnings
+  [form]
+  (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/disallow-hardcoded-driver-names-in-tests {:level :warning}}}
+                                        :ignores    (atom nil)
+                                        :findings   (atom [])
+                                        :namespaces (atom {})}]
+    (hooks.clojure.test/deftest {:node   (api/parse-string form)
+                                 :config {:linters
+                                          {:metabase/disallow-hardcoded-driver-names-in-tests
+                                           {:drivers
+                                            #{:athena}}}}})
+    (mapv :message @(:findings clj-kondo.impl.utils/*ctx*))))
+
+(deftest ^:parallel disallow-hardcoded-driver-names-in-tests-test
+  (is (= []
+         (deftest-warnings
+           "(mt/test-drivers (mt/normal-drivers)
+              (do-something))")))
+  (is (= ["Do not hardcode driver name :athena in driver tests! [:metabase/disallow-hardcoded-driver-names-in-tests]"]
+         (deftest-warnings
+           "(mt/test-drivers (mt/normal-drivers)
+              (when-not (= driver/*driver* :athena)
+                (do-something)))")))
+  (testing "make sure :clj-kondo/ignore is propagated correctly"
+    (is (= []
+           (deftest-warnings
+             "(mt/test-drivers (mt/normal-drivers)
+                #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                (when-not (= driver/*driver* :athena)
+                  (do-something)))")))))


### PR DESCRIPTION
This is a change to upgrade the version of Metabase to 1.52.2. Among the changes are a few API changes, some driver properties to change in order for some tests not to run (which are not expected to work for any Presto/Trino-like driver) and a test removed from the Metabase tests (`check-driver-keywords-test`)